### PR TITLE
fix module export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,1 @@
-const rbp = require('./build/Release/rectangle_bin_pack');
-
-var a = [{w: 10, h: 10}, {w: 60, h: 60}, {w: 10, h: 10}];
-rbp.solveSync({w: 50, h: 50}, a);
-console.log(a);
+module.exports = require('./build/Release/rectangle_bin_pack');

--- a/test.js
+++ b/test.js
@@ -1,0 +1,5 @@
+const rbp = require('.');
+
+var a = [{w: 10, h: 10}, {w: 60, h: 60}, {w: 10, h: 10}];
+rbp.solveSync({w: 50, h: 50}, a);
+console.log(a);


### PR DESCRIPTION
Looks like the README usage instructions are broken because the `package.json` exports a test case rather than the library. This seems to fix it for me.